### PR TITLE
docker container to run language models in isolation to main config

### DIFF
--- a/Docker-Compose.yml
+++ b/Docker-Compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+
+services:
+  lang-detect:
+    build: ./language_detect_model
+    volumes:
+      - ./temp:/data

--- a/language_detection_models/Dockerfile
+++ b/language_detection_models/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "lang_detect.py"]


### PR DESCRIPTION
using docker to isolate numpy version < 2.0 required by fasttext, from the numpy version >2.0 required by opencv and ppocrv5 